### PR TITLE
Fix validation and visit types

### DIFF
--- a/server/logic/validation.ts
+++ b/server/logic/validation.ts
@@ -3,7 +3,7 @@ import { Request, Response, NextFunction } from "express";
 
 export function validateVisitData(req: Request, res: Response, next: NextFunction) {
   try {
-    const validatedData = insertVisitSchema.omit({ userId: true }).parse(req.body);
+    const validatedData = insertVisitSchema.parse(req.body);
     req.body = validatedData;
     next();
   } catch (error: any) {

--- a/server/logic/visit.ts
+++ b/server/logic/visit.ts
@@ -24,10 +24,10 @@ export async function createVisit(userId: number, visitData: CreateVisitRequest)
     countryCode: validatedData.countryCode,
     countryName: validatedData.countryName,
     state: visitData.state || null,
-    city: visitData.city || null,
+    city: validatedData.city,
     visitMonth: validatedData.visitMonth,
     visitYear: validatedData.visitYear,
-    notes: visitData.notes || null,
+    notes: validatedData.notes ?? null,
   });
 
   return newVisit;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19,7 +19,9 @@ export interface IStorage {
   // Visit methods
   getVisitById(id: number): Promise<Visit | undefined>;
   getVisitsByUserId(userId: number): Promise<Visit[]>;
-  createVisit(visit: Omit<Visit, 'id'>): Promise<Visit>;
+  createVisit(
+    visit: Omit<Visit, 'id' | 'visitDate'> & { visitDate?: string | null }
+  ): Promise<Visit>;
   updateVisit(id: number, visit: Partial<Omit<Visit, 'id' | 'userId'>>): Promise<Visit | undefined>;
   deleteVisit(id: number): Promise<boolean>;
   
@@ -125,7 +127,9 @@ export class DatabaseStorage implements IStorage {
     return userVisits;
   }
 
-  async createVisit(visit: Omit<Visit, 'id'>): Promise<Visit> {
+  async createVisit(
+    visit: Omit<Visit, 'id' | 'visitDate'> & { visitDate?: string | null }
+  ): Promise<Visit> {
     const [newVisit] = await db
       .insert(visits)
       .values({

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -2,7 +2,11 @@ import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from 'url';
-import { createServer as createViteServer, createLogger } from "vite";
+import {
+  createServer as createViteServer,
+  createLogger,
+  type ServerOptions,
+} from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -23,7 +27,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,


### PR DESCRIPTION
## Summary
- fix validation schema usage
- fix createVisit to use validated data
- update createVisit type to accept optional visitDate
- type server options for Vite setup

## Testing
- `npm test`
- `npm run check` *(fails: TS errors in client pages)*

------
https://chatgpt.com/codex/tasks/task_e_6840712255248325bff9c7038045a2e7